### PR TITLE
Add tailwind snippet example

### DIFF
--- a/python_snippet_tailwind.html
+++ b/python_snippet_tailwind.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Python Snippet met Copy-knop</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 p-6">
+  <div class="max-w-2xl mx-auto">
+    <h1 class="text-2xl font-bold mb-4">Voorbeeld Python Code</h1>
+    <div class="relative bg-gray-800 text-green-300 font-mono rounded-lg p-4">
+      <button id="copyBtn" class="absolute top-2 right-2 bg-blue-500 hover:bg-blue-700 text-white px-2 py-1 rounded text-sm">Kopieer</button>
+      <pre><code id="code" class="whitespace-pre">
+# Voorbeeld: eenvoudige functie in Python
+def hello(name):
+    print(f"Hello {name}")
+
+if __name__ == "__main__":
+    hello("Wereld")
+      </code></pre>
+    </div>
+  </div>
+  <script>
+    document.getElementById('copyBtn').addEventListener('click', () => {
+      const text = document.getElementById('code').innerText;
+      navigator.clipboard.writeText(text).then(() => {
+        alert('Code gekopieerd naar klembord!');
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone HTML page showing Python code snippet
- implement copy button using Tailwind CSS

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683f3f8cbb848331a5b050b5f059cffb