### PR TITLE
Add Flask chi-square generator app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Data-Science-AI
+
+Deze repository bevat een voorbeeld Flask-webapplicatie om chi-kwadraat gerelateerde analyses te genereren. Volg de stappen hieronder om de app lokaal te draaien.
+
+```markdown
+# Instructies om te draaien:
+1. Maak een virtuele omgeving en activeer die: `python -m venv venv && source venv/bin/activate`
+2. Installeer afhankelijkheden: `pip install -r requirements.txt`
+3. Start de server: `python app.py`
+4. Open in de browser: `http://127.0.0.1:5000/`
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,109 @@
+from flask import Flask, render_template, request
+
+app = Flask(__name__)
+
+# Helper function to build the Python analysis script
+def build_script(filetype, filename, var1, type1, var2, type2, options):
+    lines = [
+        'import pandas as pd',
+        'import numpy as np',
+        'import seaborn as sns',
+        'import matplotlib.pyplot as plt',
+        'from scipy import stats',
+        'import statsmodels.api as sm',
+        '',
+        '# Laad je dataset',
+    ]
+    if filetype == 'csv':
+        lines.append(f"df = pd.read_csv('{filename}')  # Pas hier de bestandsnaam aan")
+    else:
+        lines.append(f"df = pd.read_excel('{filename}')  # Pas hier de bestandsnaam aan")
+    lines += [
+        f"df['{var1}'] = df['{var1}'].astype('{type1}')  # Pas hier '{var1}' aan naar jouw kolomnaam",
+        f"df['{var2}'] = df['{var2}'].astype('{type2}')  # Pas hier '{var2}' aan naar jouw kolomnaam",
+        '',
+        "contingency = pd.crosstab(df['" + var1 + "'], df['" + var2 + "'])",
+        'print(contingency)',
+        '',
+    ]
+
+    if 'chi2' in options:
+        lines += [
+            '# Chi-kwadraattest',
+            'chi2, p, dof, expected = stats.chi2_contingency(contingency)',
+            'print("Chi-square statistic:", chi2)',
+            'print("p-value:", p)',
+            '',
+        ]
+    if 'cramers_v' in options:
+        lines += [
+            '# Bereken Cram\u00e9r\'s V',
+            'n = contingency.sum().sum()',
+            'phi2 = (chi2 / n)',
+            'r, k = contingency.shape',
+            'cramers_v = np.sqrt(phi2 / (min(k - 1, r - 1)))',
+            'print("Cram\u00e9r\'s V:", cramers_v)',
+            '',
+        ]
+    if 'residuals' in options:
+        lines += [
+            '# Gestandaardiseerde residuen',
+            'residuals = (contingency - expected) / np.sqrt(expected)',
+            'print("Gestandaardiseerde residuen:")',
+            'print(residuals)',
+            '',
+        ]
+    if 'clustered_bar' in options:
+        lines += [
+            '# Clustered bar chart',
+            "contingency.plot(kind='bar')",
+            'plt.xlabel("' + var1 + '")',
+            'plt.ylabel("Frequentie")',
+            'plt.title("Clustered Bar Chart")',
+            'plt.show()',
+            '',
+        ]
+    if 'mosaic' in options:
+        lines += [
+            '# Mosaic plot',
+            'from statsmodels.graphics.mosaicplot import mosaic',
+            "mosaic(df, [\'" + var1 + "\', \'" + var2 + "\'])",
+            'plt.show()',
+            '',
+        ]
+
+    return "\n".join(lines)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/generate', methods=['POST'])
+def generate():
+    filetype = request.form.get('filetype')
+    filename = request.form.get('filename')
+    var1 = request.form.get('var1')
+    type1 = request.form.get('type1')
+    var2 = request.form.get('var2')
+    type2 = request.form.get('type2')
+    options = request.form.getlist('options')
+
+    script = build_script(filetype, filename, var1, type1, var2, type2, options)
+
+    # Schrijf requirements.txt
+    with open('requirements.txt', 'w') as f:
+        f.write('\n'.join([
+            'Flask',
+            'pandas',
+            'scipy',
+            'numpy',
+            'seaborn',
+            'matplotlib',
+            'statsmodels',
+        ]))
+
+    return render_template('result.html', script=script)
+
+if __name__ == '__main__':
+    app.run(debug=True)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Flask
+pandas
+scipy
+numpy
+seaborn
+matplotlib
+statsmodels

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,12 @@
+body {
+    font-family: Arial, sans-serif;
+    max-width: 800px;
+    margin: 40px auto;
+    padding: 20px;
+    background-color: #f5f5f5;
+}
+pre {
+    background-color: #eee;
+    padding: 10px;
+    overflow-x: auto;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Chi-Square Tool</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+    <h1>Upload Data and Select Options</h1>
+    <form action="/generate" method="post">
+        <label>Bestandstype:</label><br>
+        <input type="radio" name="filetype" value="csv" checked>CSV
+        <input type="radio" name="filetype" value="excel">Excel<br><br>
+        <label>Bestandsnaam (met extensie):</label>
+        <input type="text" name="filename" placeholder="data.csv"><br><br>
+        <label>Eerste categorische variabele:</label>
+        <input type="text" name="var1" placeholder="bijv. 'gender'"><br>
+        <label>Eerste variabele type:</label>
+        <input type="text" name="type1" placeholder="bijv. 'category'"><br><br>
+        <label>Tweede categorische variabele:</label>
+        <input type="text" name="var2" placeholder="bijv. 'age'"><br>
+        <label>Tweede variabele type:</label>
+        <input type="text" name="type2" placeholder="bijv. 'category'"><br><br>
+        <fieldset>
+            <legend>Kies analyses/plots:</legend>
+            <input type="checkbox" name="options" value="chi2">Chi-kwadraattest<br>
+            <input type="checkbox" name="options" value="cramers_v">Cramér's V<br>
+            <input type="checkbox" name="options" value="residuals">Gestandaardiseerde residuen<br>
+            <input type="checkbox" name="options" value="clustered_bar">Clustered bar chart<br>
+            <input type="checkbox" name="options" value="mosaic">Mosaic plot<br>
+        </fieldset>
+        <br>
+        <button type="submit">Genereer Python-script</button>
+    </form>
+</body>
+</html>

--- a/templates/result.html
+++ b/templates/result.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Gegenereerd Script</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+    <h1>Voer dit script uit in je eigen Python omgeving</h1>
+    <pre><code>{{ script }}</code></pre>
+    <!-- Instructies om te draaien:
+    1. Maak een virtuele omgeving en activeer die: `python -m venv venv && source venv/bin/activate`
+    2. Installeer afhankelijkheden: `pip install -r requirements.txt`
+    3. Start de server: `python app.py`
+    4. Open in de browser: `http://127.0.0.1:5000/`
+    -->
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a minimal Flask app to generate chi-square analysis scripts
- add HTML templates with placeholders for column names and file names
- add basic CSS styling
- generate requirements.txt and update README with run instructions

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_b_683f42f2e07083319ff76c016c50299d